### PR TITLE
feat(repo): add paginated request status listing with feature join

### DIFF
--- a/apps/backend/app/api/requests.py
+++ b/apps/backend/app/api/requests.py
@@ -1,0 +1,23 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+
+from app.dependencies import get_feature_request_service
+from app.schemas.request_status import RequestListResponse, RequestStatus
+from app.services.feature_request_service import FeatureRequestService
+
+router = APIRouter(prefix="/requests", tags=["requests"])
+
+
+@router.get("", response_model=RequestListResponse)
+def list_requests(
+    feature_request_service: Annotated[FeatureRequestService, Depends(get_feature_request_service)],
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> RequestListResponse:
+    items = feature_request_service.list_requests(limit=limit, offset=offset)
+    return RequestListResponse(
+        items=[RequestStatus(**item) for item in items],
+        limit=limit,
+        offset=offset,
+    )

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -4,9 +4,11 @@ from app.api.feature_requests import router as feature_requests_router
 from app.api.features import router as features_router
 from app.api.health import router as health_router
 from app.api.moods import router as moods_router
+from app.api.requests import router as requests_router
 
 app = FastAPI(title="Mood Platform API")
 app.include_router(health_router)
 app.include_router(moods_router)
 app.include_router(feature_requests_router)
 app.include_router(features_router)
+app.include_router(requests_router)

--- a/apps/backend/app/repositories/feature_request_repository.py
+++ b/apps/backend/app/repositories/feature_request_repository.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
+import sqlalchemy as sa
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.db.models import FeatureRequest
+from app.db.models import Feature, FeatureRequest
 
 PENDING_STATUS = "pending"
 PHONE_SOURCE = "phone"
@@ -38,3 +39,26 @@ class FeatureRequestRepository:
         except IntegrityError as exc:
             self._session.rollback()
             raise FeatureRequestWriteError("Failed to create feature request.") from exc
+
+    def list_requests(
+        self,
+        *,
+        user_id: str,
+        limit: int,
+        offset: int,
+    ) -> list[tuple[FeatureRequest, Feature | None]]:
+        result = self._session.execute(
+            sa.select(FeatureRequest, Feature)
+            .outerjoin(
+                Feature,
+                sa.and_(
+                    Feature.id == FeatureRequest.feature_id,
+                    Feature.user_id == FeatureRequest.user_id,
+                ),
+            )
+            .where(FeatureRequest.user_id == user_id)
+            .order_by(FeatureRequest.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        return [(row[0], row[1]) for row in result.all()]

--- a/apps/backend/app/schemas/request_status.py
+++ b/apps/backend/app/schemas/request_status.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel
+
+
+class RequestFeatureMetadata(BaseModel):
+    id: str
+    createdAt: int
+    source: str
+
+
+class RequestStatus(BaseModel):
+    id: str
+    createdAt: int
+    status: str
+    source: str
+    featureId: str | None
+    feature: RequestFeatureMetadata | None = None
+
+
+class RequestListResponse(BaseModel):
+    items: list[RequestStatus]
+    limit: int
+    offset: int

--- a/apps/backend/app/services/feature_request_service.py
+++ b/apps/backend/app/services/feature_request_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from typing import Any
 
 from app.repositories.feature_request_repository import (
     FeatureRequestRepository,
@@ -22,3 +23,27 @@ class FeatureRequestService:
             return self._repository.create_request(user_id=str(self._owner_user_id))
         except FeatureRequestWriteError as exc:
             raise FeatureRequestPersistenceError(str(exc)) from exc
+
+    def list_requests(self, *, limit: int, offset: int) -> list[dict[str, Any]]:
+        request_rows = self._repository.list_requests(
+            user_id=str(self._owner_user_id),
+            limit=limit,
+            offset=offset,
+        )
+        items: list[dict[str, Any]] = []
+        for request, feature in request_rows:
+            payload: dict[str, Any] = {
+                "id": request.id,
+                "createdAt": request.created_at,
+                "status": request.status,
+                "source": request.source,
+                "featureId": request.feature_id,
+            }
+            if feature is not None:
+                payload["feature"] = {
+                    "id": feature.id,
+                    "createdAt": feature.created_at,
+                    "source": feature.source,
+                }
+            items.append(payload)
+        return items

--- a/apps/backend/tests/test_requests_status.py
+++ b/apps/backend/tests/test_requests_status.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import psycopg
+from app.db import session as db_session
+from app.main import app
+from fastapi.testclient import TestClient
+from psycopg import sql
+from sqlalchemy.engine import make_url
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+ALEMBIC_CONFIG = ROOT_DIR / "apps" / "backend" / "alembic.ini"
+CURRENT_USER_ID = "00000000-0000-0000-0000-00000000dd01"
+OTHER_USER_ID = "00000000-0000-0000-0000-00000000dd02"
+
+
+def test_get_requests_returns_empty_list_when_no_requests(monkeypatch) -> None:
+    with _temporary_database() as database_url:
+        _run_alembic_upgrade(database_url=database_url)
+        _configure_runtime_env(monkeypatch=monkeypatch, database_url=database_url)
+
+        with TestClient(app) as client:
+            response = client.get("/requests")
+
+        assert response.status_code == 200
+        assert response.json() == {"items": [], "limit": 20, "offset": 0}
+
+        db_session._session_factory.cache_clear()
+
+
+def test_get_requests_includes_pending_request(monkeypatch) -> None:
+    with _temporary_database() as database_url:
+        _run_alembic_upgrade(database_url=database_url)
+        _configure_runtime_env(monkeypatch=monkeypatch, database_url=database_url)
+        _insert_request(
+            database_url=database_url,
+            request_id="req_pending_1",
+            user_id=CURRENT_USER_ID,
+            created_at=1700000000,
+            status="pending",
+            source="phone",
+            feature_id=None,
+        )
+
+        with TestClient(app) as client:
+            response = client.get("/requests")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "items": [
+                {
+                    "id": "req_pending_1",
+                    "createdAt": 1700000000,
+                    "status": "pending",
+                    "source": "phone",
+                    "featureId": None,
+                    "feature": None,
+                }
+            ],
+            "limit": 20,
+            "offset": 0,
+        }
+
+        db_session._session_factory.cache_clear()
+
+
+def test_get_requests_includes_feature_id_for_fulfilled_request(monkeypatch) -> None:
+    with _temporary_database() as database_url:
+        _run_alembic_upgrade(database_url=database_url)
+        _configure_runtime_env(monkeypatch=monkeypatch, database_url=database_url)
+        _insert_feature(
+            database_url=database_url,
+            feature_id="feat_1",
+            user_id=CURRENT_USER_ID,
+            created_at=1700000200,
+            source="phone-request",
+            data={"steps": 1200},
+        )
+        _insert_request(
+            database_url=database_url,
+            request_id="req_fulfilled_1",
+            user_id=CURRENT_USER_ID,
+            created_at=1700000100,
+            status="fulfilled",
+            source="phone",
+            feature_id="feat_1",
+        )
+
+        with TestClient(app) as client:
+            response = client.get("/requests")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "items": [
+                {
+                    "id": "req_fulfilled_1",
+                    "createdAt": 1700000100,
+                    "status": "fulfilled",
+                    "source": "phone",
+                    "featureId": "feat_1",
+                    "feature": {
+                        "id": "feat_1",
+                        "createdAt": 1700000200,
+                        "source": "phone-request",
+                    },
+                }
+            ],
+            "limit": 20,
+            "offset": 0,
+        }
+
+        db_session._session_factory.cache_clear()
+
+
+def test_get_requests_applies_pagination_and_ordering(monkeypatch) -> None:
+    with _temporary_database() as database_url:
+        _run_alembic_upgrade(database_url=database_url)
+        _configure_runtime_env(monkeypatch=monkeypatch, database_url=database_url)
+        _insert_request(
+            database_url=database_url,
+            request_id="req_1",
+            user_id=CURRENT_USER_ID,
+            created_at=1700000000,
+            status="pending",
+            source="phone",
+            feature_id=None,
+        )
+        _insert_request(
+            database_url=database_url,
+            request_id="req_2",
+            user_id=CURRENT_USER_ID,
+            created_at=1700000100,
+            status="pending",
+            source="phone",
+            feature_id=None,
+        )
+        _insert_request(
+            database_url=database_url,
+            request_id="req_3",
+            user_id=CURRENT_USER_ID,
+            created_at=1700000200,
+            status="pending",
+            source="phone",
+            feature_id=None,
+        )
+        _insert_request(
+            database_url=database_url,
+            request_id="req_other_user",
+            user_id=OTHER_USER_ID,
+            created_at=1700000300,
+            status="pending",
+            source="phone",
+            feature_id=None,
+        )
+
+        with TestClient(app) as client:
+            first_page = client.get("/requests?limit=1&offset=0")
+            second_page = client.get("/requests?limit=1&offset=1")
+
+        assert first_page.status_code == 200
+        assert first_page.json() == {
+            "items": [
+                {
+                    "id": "req_3",
+                    "createdAt": 1700000200,
+                    "status": "pending",
+                    "source": "phone",
+                    "featureId": None,
+                    "feature": None,
+                }
+            ],
+            "limit": 1,
+            "offset": 0,
+        }
+
+        assert second_page.status_code == 200
+        assert second_page.json() == {
+            "items": [
+                {
+                    "id": "req_2",
+                    "createdAt": 1700000100,
+                    "status": "pending",
+                    "source": "phone",
+                    "featureId": None,
+                    "feature": None,
+                }
+            ],
+            "limit": 1,
+            "offset": 1,
+        }
+
+        db_session._session_factory.cache_clear()
+
+
+class _temporary_database:
+    def __enter__(self) -> str:
+        base_database_url = os.getenv("DATABASE_URL", "").strip()
+        if not base_database_url:
+            raise RuntimeError("DATABASE_URL is required for request status integration tests.")
+
+        parsed_url = make_url(base_database_url)
+        if not parsed_url.database:
+            raise RuntimeError("DATABASE_URL must include a database name.")
+
+        self._temp_database = f"mood_request_status_{uuid.uuid4().hex[:8]}"
+        self._admin_url = parsed_url.set(database="postgres").render_as_string(hide_password=False)
+        self._temp_url = parsed_url.set(database=self._temp_database).render_as_string(
+            hide_password=False
+        )
+
+        with psycopg.connect(self._admin_url, autocommit=True) as connection:
+            connection.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(
+                    sql.Identifier(self._temp_database)
+                )
+            )
+            connection.execute(
+                sql.SQL("CREATE DATABASE {}").format(sql.Identifier(self._temp_database))
+            )
+
+        return self._temp_url
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        with psycopg.connect(self._admin_url, autocommit=True) as connection:
+            connection.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(
+                    sql.Identifier(self._temp_database)
+                )
+            )
+
+
+def _run_alembic_upgrade(*, database_url: str) -> None:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "alembic",
+            "-c",
+            str(ALEMBIC_CONFIG),
+            "upgrade",
+            "head",
+        ],
+        check=True,
+        cwd=ROOT_DIR,
+        env=env,
+    )
+
+
+def _configure_runtime_env(*, monkeypatch, database_url: str) -> None:
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("OWNER_USER_ID", CURRENT_USER_ID)
+    db_session._session_factory.cache_clear()
+
+
+def _insert_request(
+    *,
+    database_url: str,
+    request_id: str,
+    user_id: str,
+    created_at: int,
+    status: str,
+    source: str,
+    feature_id: str | None,
+) -> None:
+    with psycopg.connect(database_url) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO requests (id, "userId", "createdAt", status, source, "featureId")
+                VALUES (%s, %s, %s, %s, %s, %s)
+                """,
+                (request_id, user_id, created_at, status, source, feature_id),
+            )
+        connection.commit()
+
+
+def _insert_feature(
+    *,
+    database_url: str,
+    feature_id: str,
+    user_id: str,
+    created_at: int,
+    source: str,
+    data: dict[str, object],
+) -> None:
+    with psycopg.connect(database_url) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO features (id, "userId", "createdAt", source, data)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (feature_id, user_id, created_at, source, json.dumps(data)),
+            )
+        connection.commit()


### PR DESCRIPTION
Implements a paginated endpoint for listing a user's feature requests along with their fulfillment status and associated feature data.

## What was added
- API endpoint to list requests for a user
- Pagination support (`limit` / `offset`)
- Join between `requests` and `features` tables so fulfilled requests include the generated feature record
- Response structure exposing:
  - request id
  - createdAt
  - status (`pending`, `fulfilled`, `canceled`)
  - featureId (if fulfilled)
  - request source

## Why
This allows the client to view the history and current state of feature requests made from the phone. It also enables the UI to determine whether a request has been fulfilled and retrieve the associated feature data.

## Behavior
- Results are ordered by newest request first
- Supports pagination to prevent large response payloads
- Fulfilled requests include their associated `featureId`

## Files touched
- `apps/backend/app/api/requests.py`
- request service / repository logic
- response schema updates
- tests verifying pagination and join behavior

## Tests
- Verified requests list returns correct statuses
- Verified fulfilled requests include their `featureId`
- Verified pagination (`limit`, `offset`) works correctly