### PR TITLE
US-023: Add request->feature->label traceability with circumplex labels

### DIFF
--- a/apps/backend/alembic/versions/20260305_000013_add_labels_table.py
+++ b/apps/backend/alembic/versions/20260305_000013_add_labels_table.py
@@ -1,0 +1,59 @@
+"""add labels table linked to fulfilled request features
+
+Revision ID: 20260305_000013
+Revises: 20260305_000012
+Create Date: 2026-03-05 00:00:13.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20260305_000013"
+down_revision: str | None = "20260305_000012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "labels",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("userId", sa.Text(), nullable=False),
+        sa.Column("featureId", sa.Text(), nullable=False),
+        sa.Column("requestId", sa.Text(), nullable=False),
+        sa.Column("label", sa.Text(), nullable=True),
+        sa.Column("emotionWord", sa.Text(), nullable=False),
+        sa.Column("category", sa.Text(), nullable=False),
+        sa.Column(
+            "createdAt",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "category IN ('energized','calm','stressed','tired')",
+            name="ck_labels_category",
+        ),
+        sa.ForeignKeyConstraint(["featureId"], ["features.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["requestId"], ["requests.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_labels_feature_id", "labels", ["featureId"], unique=False)
+    op.create_index("ix_labels_request_id", "labels", ["requestId"], unique=False)
+    op.create_index(
+        "ix_labels_user_created_at_desc",
+        "labels",
+        ["userId", sa.text('"createdAt" DESC')],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_labels_user_created_at_desc", table_name="labels")
+    op.drop_index("ix_labels_request_id", table_name="labels")
+    op.drop_index("ix_labels_feature_id", table_name="labels")
+    op.drop_table("labels")

--- a/apps/backend/app/api/labels.py
+++ b/apps/backend/app/api/labels.py
@@ -1,0 +1,39 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.dependencies import get_label_service
+from app.schemas.label import CreateLabelRequest, LabelResponse
+from app.services.label_service import (
+    LabelFeatureReferenceError,
+    LabelPersistenceError,
+    LabelService,
+    LabelTraceabilityError,
+    LabelValidationError,
+)
+
+router = APIRouter(prefix="/labels", tags=["labels"])
+
+
+@router.post("", response_model=LabelResponse, status_code=status.HTTP_201_CREATED)
+def create_label(
+    payload: CreateLabelRequest,
+    label_service: Annotated[LabelService, Depends(get_label_service)],
+) -> LabelResponse:
+    try:
+        created = label_service.create(
+            feature_id=payload.featureId,
+            label=payload.label,
+            emotion_word=payload.emotionWord,
+            category=payload.category,
+        )
+    except LabelValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except LabelFeatureReferenceError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except LabelTraceabilityError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except LabelPersistenceError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return LabelResponse(**created)

--- a/apps/backend/app/db/models.py
+++ b/apps/backend/app/db/models.py
@@ -61,6 +61,43 @@ class Feature(Base):
     window_end: Mapped[datetime | None] = mapped_column("windowEnd", sa.DateTime(timezone=True))
 
 
+class Label(Base):
+    __tablename__ = "labels"
+    __table_args__ = (
+        sa.CheckConstraint(
+            "category IN ('energized','calm','stressed','tired')",
+            name="ck_labels_category",
+        ),
+        sa.Index("ix_labels_feature_id", "featureId"),
+        sa.Index("ix_labels_request_id", "requestId"),
+        sa.Index("ix_labels_user_created_at_desc", "userId", sa.text('"createdAt" DESC')),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[str] = mapped_column("userId", sa.Text, nullable=False)
+    feature_id: Mapped[str] = mapped_column(
+        "featureId",
+        sa.Text,
+        sa.ForeignKey("features.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    request_id: Mapped[str] = mapped_column(
+        "requestId",
+        sa.Text,
+        sa.ForeignKey("requests.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    label: Mapped[str | None] = mapped_column(sa.Text)
+    emotion_word: Mapped[str] = mapped_column("emotionWord", sa.Text, nullable=False)
+    category: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        "createdAt",
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+
 class WorkerLock(Base):
     __tablename__ = "worker_locks"
     __table_args__ = (sa.Index("ix_worker_locks_expires_at", "expires_at"),)

--- a/apps/backend/app/dependencies.py
+++ b/apps/backend/app/dependencies.py
@@ -12,6 +12,7 @@ from app.repositories.feature_request_repository import FeatureRequestRepository
 from app.repositories.feature_set_repository import FeatureSetRepository
 from app.repositories.fitbit_oauth_repository import FitbitOAuthRepository
 from app.repositories.fitbit_token_repository import FitbitTokenRepository
+from app.repositories.label_repository import LabelRepository
 from app.repositories.mood_entry_repository import MoodEntryRepository
 from app.repositories.postgres import PostgresRepository
 from app.repositories.redis import RedisRepository
@@ -23,6 +24,7 @@ from app.services.fitbit_oauth_service import FitbitOAuthService
 from app.services.fitbit_token_service import FitbitTokenService
 from app.services.fitbit_webhook_ingestion_service import FitbitWebhookIngestionService
 from app.services.health_service import HealthService
+from app.services.label_service import LabelService
 from app.services.mood_entry_service import MoodEntryService, get_owner_user_id
 from app.services.request_fulfillment_service import RequestFulfillmentService
 from app.services.webhook_coalescer import WebhookCoalescer
@@ -53,6 +55,12 @@ def get_mood_entry_repository(
     db_session: Annotated[Session, Depends(get_db_session)],
 ) -> MoodEntryRepository:
     return MoodEntryRepository(session=db_session)
+
+
+def get_label_repository(
+    db_session: Annotated[Session, Depends(get_db_session)],
+) -> LabelRepository:
+    return LabelRepository(session=db_session)
 
 
 def get_feature_set_repository(
@@ -158,6 +166,15 @@ def get_mood_entry_service(
 ) -> MoodEntryService:
     return MoodEntryService(
         repository=mood_entry_repository,
+        owner_user_id=get_owner_user_id(),
+    )
+
+
+def get_label_service(
+    label_repository: Annotated[LabelRepository, Depends(get_label_repository)],
+) -> LabelService:
+    return LabelService(
+        repository=label_repository,
         owner_user_id=get_owner_user_id(),
     )
 

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -6,6 +6,7 @@ from app.api.fitbit_oauth import router as fitbit_oauth_router
 from app.api.fitbit_proxy import router as fitbit_proxy_router
 from app.api.fitbit_webhook import router as fitbit_webhook_router
 from app.api.health import router as health_router
+from app.api.labels import router as labels_router
 from app.api.moods import router as moods_router
 from app.api.requests import router as requests_router
 from app.middleware.raw_body import RawBodyMiddleware
@@ -20,3 +21,4 @@ app.include_router(requests_router)
 app.include_router(fitbit_oauth_router)
 app.include_router(fitbit_proxy_router)
 app.include_router(fitbit_webhook_router)
+app.include_router(labels_router)

--- a/apps/backend/app/repositories/label_repository.py
+++ b/apps/backend/app/repositories/label_repository.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.db.models import Feature, FeatureRequest, Label
+
+
+class LabelFeatureNotFoundError(Exception):
+    pass
+
+
+class LabelRequestNotFoundError(Exception):
+    pass
+
+
+class LabelWriteError(Exception):
+    pass
+
+
+class LabelRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create_label(
+        self,
+        *,
+        user_id: str,
+        feature_id: str,
+        label: str | None,
+        emotion_word: str,
+        category: str,
+    ) -> Label:
+        feature_owner = self._session.execute(
+            sa.select(Feature.user_id).where(
+                Feature.id == feature_id,
+                Feature.user_id == user_id,
+            )
+        ).scalar_one_or_none()
+        if feature_owner is None:
+            raise LabelFeatureNotFoundError(f"Feature {feature_id} was not found for current user.")
+
+        request_id = self._session.execute(
+            sa.select(FeatureRequest.id)
+            .where(
+                FeatureRequest.feature_id == feature_id,
+                FeatureRequest.user_id == user_id,
+            )
+            .order_by(FeatureRequest.created_at.desc())
+            .limit(1)
+        ).scalar_one_or_none()
+        if request_id is None:
+            raise LabelRequestNotFoundError(
+                f"Feature {feature_id} is not linked to a fulfilled request."
+            )
+
+        try:
+            row = Label(
+                user_id=user_id,
+                feature_id=feature_id,
+                request_id=request_id,
+                label=label,
+                emotion_word=emotion_word,
+                category=category,
+            )
+            self._session.add(row)
+            self._session.commit()
+            self._session.refresh(row)
+            return row
+        except IntegrityError as exc:
+            self._session.rollback()
+            raise LabelWriteError("Failed to create label.") from exc

--- a/apps/backend/app/schemas/label.py
+++ b/apps/backend/app/schemas/label.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class CreateLabelRequest(BaseModel):
+    featureId: str = Field(min_length=1)
+    label: str | None = None
+    emotionWord: str = Field(min_length=1)
+    category: Literal["energized", "calm", "stressed", "tired"]
+
+
+class LabelResponse(BaseModel):
+    id: uuid.UUID
+    userId: str
+    featureId: str
+    requestId: str
+    label: str | None
+    emotionWord: str
+    category: Literal["energized", "calm", "stressed", "tired"]
+    createdAt: datetime

--- a/apps/backend/app/services/label_service.py
+++ b/apps/backend/app/services/label_service.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from app.repositories.label_repository import (
+    LabelFeatureNotFoundError,
+    LabelRepository,
+    LabelRequestNotFoundError,
+    LabelWriteError,
+)
+
+
+class LabelValidationError(Exception):
+    pass
+
+
+class LabelFeatureReferenceError(Exception):
+    pass
+
+
+class LabelTraceabilityError(Exception):
+    pass
+
+
+class LabelPersistenceError(Exception):
+    pass
+
+
+class LabelService:
+    def __init__(self, repository: LabelRepository, owner_user_id: uuid.UUID) -> None:
+        self._repository = repository
+        self._owner_user_id = owner_user_id
+
+    def create(
+        self,
+        *,
+        feature_id: str,
+        label: str | None,
+        emotion_word: str,
+        category: str,
+    ) -> dict[str, Any]:
+        normalized_feature_id = feature_id.strip()
+        if not normalized_feature_id:
+            raise LabelValidationError("featureId must not be blank.")
+
+        normalized_emotion_word = emotion_word.strip()
+        if not normalized_emotion_word:
+            raise LabelValidationError("emotionWord must not be blank.")
+
+        normalized_label: str | None = None
+        if isinstance(label, str):
+            stripped_label = label.strip()
+            if stripped_label:
+                normalized_label = stripped_label
+
+        try:
+            created = self._repository.create_label(
+                user_id=str(self._owner_user_id),
+                feature_id=normalized_feature_id,
+                label=normalized_label,
+                emotion_word=normalized_emotion_word,
+                category=category,
+            )
+        except LabelFeatureNotFoundError as exc:
+            raise LabelFeatureReferenceError(str(exc)) from exc
+        except LabelRequestNotFoundError as exc:
+            raise LabelTraceabilityError(str(exc)) from exc
+        except LabelWriteError as exc:
+            raise LabelPersistenceError(str(exc)) from exc
+
+        return {
+            "id": created.id,
+            "userId": created.user_id,
+            "featureId": created.feature_id,
+            "requestId": created.request_id,
+            "label": created.label,
+            "emotionWord": created.emotion_word,
+            "category": created.category,
+            "createdAt": created.created_at,
+        }

--- a/apps/backend/tests/test_labels_endpoint.py
+++ b/apps/backend/tests/test_labels_endpoint.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import psycopg
+from app.db import session as db_session
+from app.main import app
+from fastapi.testclient import TestClient
+from psycopg import sql
+from sqlalchemy.engine import make_url
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+ALEMBIC_CONFIG = ROOT_DIR / "apps" / "backend" / "alembic.ini"
+CURRENT_USER_ID = "00000000-0000-0000-0000-00000000ef01"
+OTHER_USER_ID = "00000000-0000-0000-0000-00000000ef02"
+
+
+def test_post_labels_creates_label_for_owned_feature(monkeypatch) -> None:
+    with _temporary_database() as database_url:
+        _run_alembic_upgrade(database_url=database_url)
+        _configure_runtime_env(monkeypatch=monkeypatch, database_url=database_url)
+        feature_id = "11111111-1111-1111-1111-111111111111"
+        request_id = "req-label-1"
+        _insert_feature(
+            database_url=database_url,
+            feature_id=feature_id,
+            user_id=CURRENT_USER_ID,
+            created_at=1700000000,
+            source="fitbit-pipeline",
+            data={"steps": {"count": 1000}},
+        )
+        _insert_request(
+            database_url=database_url,
+            request_id=request_id,
+            user_id=CURRENT_USER_ID,
+            created_at=1700000001,
+            status="fulfilled",
+            source="phone",
+            feature_id=feature_id,
+        )
+
+        with TestClient(app) as client:
+            response = client.post(
+                "/labels",
+                json={
+                    "featureId": feature_id,
+                    "label": "Felt productive",
+                    "emotionWord": "happy",
+                    "category": "energized",
+                },
+            )
+
+        assert response.status_code == 201
+        payload = response.json()
+        assert payload["userId"] == CURRENT_USER_ID
+        assert payload["featureId"] == feature_id
+        assert payload["requestId"] == request_id
+        assert payload["label"] == "Felt productive"
+        assert payload["emotionWord"] == "happy"
+        assert payload["category"] == "energized"
+        uuid.UUID(payload["id"])
+        assert isinstance(payload["createdAt"], str)
+
+        with psycopg.connect(database_url) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT "userId", "featureId", "requestId", label, "emotionWord", category
+                    FROM labels
+                    WHERE id = %s
+                    """,
+                    (payload["id"],),
+                )
+                row = cursor.fetchone()
+
+        assert row == (
+            CURRENT_USER_ID,
+            feature_id,
+            request_id,
+            "Felt productive",
+            "happy",
+            "energized",
+        )
+
+        db_session._session_factory.cache_clear()
+
+
+def test_post_labels_rejects_feature_not_owned_by_current_user(monkeypatch) -> None:
+    with _temporary_database() as database_url:
+        _run_alembic_upgrade(database_url=database_url)
+        _configure_runtime_env(monkeypatch=monkeypatch, database_url=database_url)
+        feature_id = "22222222-2222-2222-2222-222222222222"
+        _insert_feature(
+            database_url=database_url,
+            feature_id=feature_id,
+            user_id=OTHER_USER_ID,
+            created_at=1700000100,
+            source="fitbit-pipeline",
+            data={"steps": {"count": 500}},
+        )
+        _insert_request(
+            database_url=database_url,
+            request_id="req-label-2",
+            user_id=OTHER_USER_ID,
+            created_at=1700000101,
+            status="fulfilled",
+            source="phone",
+            feature_id=feature_id,
+        )
+
+        with TestClient(app) as client:
+            response = client.post(
+                "/labels",
+                json={
+                    "featureId": feature_id,
+                    "label": "Not mine",
+                    "emotionWord": "anxious",
+                    "category": "stressed",
+                },
+            )
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "detail": f"Feature {feature_id} was not found for current user."
+        }
+
+        with psycopg.connect(database_url) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT COUNT(*) FROM labels")
+                count = cursor.fetchone()[0]
+        assert count == 0
+
+        db_session._session_factory.cache_clear()
+
+
+def test_post_labels_validates_category_taxonomy(monkeypatch) -> None:
+    with _temporary_database() as database_url:
+        _run_alembic_upgrade(database_url=database_url)
+        _configure_runtime_env(monkeypatch=monkeypatch, database_url=database_url)
+
+        with TestClient(app) as client:
+            response = client.post(
+                "/labels",
+                json={
+                    "featureId": "33333333-3333-3333-3333-333333333333",
+                    "label": "Invalid category payload",
+                    "emotionWord": "okay",
+                    "category": "neutral",
+                },
+            )
+
+        assert response.status_code == 422
+        db_session._session_factory.cache_clear()
+
+
+def test_labels_cascade_when_feature_deleted(monkeypatch) -> None:
+    with _temporary_database() as database_url:
+        _run_alembic_upgrade(database_url=database_url)
+        _configure_runtime_env(monkeypatch=monkeypatch, database_url=database_url)
+        feature_id = "44444444-4444-4444-4444-444444444444"
+        request_id = "req-label-4"
+        _insert_feature(
+            database_url=database_url,
+            feature_id=feature_id,
+            user_id=CURRENT_USER_ID,
+            created_at=1700000200,
+            source="fitbit-pipeline",
+            data={"steps": {"count": 100}},
+        )
+        _insert_request(
+            database_url=database_url,
+            request_id=request_id,
+            user_id=CURRENT_USER_ID,
+            created_at=1700000201,
+            status="fulfilled",
+            source="phone",
+            feature_id=feature_id,
+        )
+        _create_label_via_api(feature_id=feature_id)
+
+        with psycopg.connect(database_url) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("DELETE FROM features WHERE id = %s", (feature_id,))
+            connection.commit()
+
+        with psycopg.connect(database_url) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute('SELECT COUNT(*) FROM labels WHERE "requestId" = %s', (request_id,))
+                count = cursor.fetchone()[0]
+        assert count == 0
+
+        db_session._session_factory.cache_clear()
+
+
+def test_labels_cascade_when_request_deleted(monkeypatch) -> None:
+    with _temporary_database() as database_url:
+        _run_alembic_upgrade(database_url=database_url)
+        _configure_runtime_env(monkeypatch=monkeypatch, database_url=database_url)
+        feature_id = "55555555-5555-5555-5555-555555555555"
+        request_id = "req-label-5"
+        _insert_feature(
+            database_url=database_url,
+            feature_id=feature_id,
+            user_id=CURRENT_USER_ID,
+            created_at=1700000300,
+            source="fitbit-pipeline",
+            data={"steps": {"count": 450}},
+        )
+        _insert_request(
+            database_url=database_url,
+            request_id=request_id,
+            user_id=CURRENT_USER_ID,
+            created_at=1700000301,
+            status="fulfilled",
+            source="phone",
+            feature_id=feature_id,
+        )
+        _create_label_via_api(feature_id=feature_id)
+
+        with psycopg.connect(database_url) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("DELETE FROM requests WHERE id = %s", (request_id,))
+            connection.commit()
+
+        with psycopg.connect(database_url) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute('SELECT COUNT(*) FROM labels WHERE "featureId" = %s', (feature_id,))
+                count = cursor.fetchone()[0]
+        assert count == 0
+
+        db_session._session_factory.cache_clear()
+
+
+def _create_label_via_api(*, feature_id: str) -> None:
+    with TestClient(app) as client:
+        response = client.post(
+            "/labels",
+            json={
+                "featureId": feature_id,
+                "label": "Linked label",
+                "emotionWord": "calm",
+                "category": "calm",
+            },
+        )
+    assert response.status_code == 201
+
+
+class _temporary_database:
+    def __enter__(self) -> str:
+        base_database_url = os.getenv("DATABASE_URL", "").strip()
+        if not base_database_url:
+            raise RuntimeError("DATABASE_URL is required for labels endpoint tests.")
+
+        parsed_url = make_url(base_database_url)
+        if not parsed_url.database:
+            raise RuntimeError("DATABASE_URL must include a database name.")
+
+        self._temp_database = f"mood_labels_{uuid.uuid4().hex[:8]}"
+        self._admin_url = parsed_url.set(database="postgres").render_as_string(hide_password=False)
+        self._temp_url = parsed_url.set(database=self._temp_database).render_as_string(
+            hide_password=False
+        )
+
+        with psycopg.connect(self._admin_url, autocommit=True) as connection:
+            connection.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(
+                    sql.Identifier(self._temp_database)
+                )
+            )
+            connection.execute(
+                sql.SQL("CREATE DATABASE {}").format(sql.Identifier(self._temp_database))
+            )
+
+        return self._temp_url
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        with psycopg.connect(self._admin_url, autocommit=True) as connection:
+            connection.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(
+                    sql.Identifier(self._temp_database)
+                )
+            )
+
+
+def _run_alembic_upgrade(*, database_url: str) -> None:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "alembic",
+            "-c",
+            str(ALEMBIC_CONFIG),
+            "upgrade",
+            "head",
+        ],
+        check=True,
+        cwd=ROOT_DIR,
+        env=env,
+    )
+
+
+def _configure_runtime_env(*, monkeypatch, database_url: str) -> None:
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("OWNER_USER_ID", CURRENT_USER_ID)
+    db_session._session_factory.cache_clear()
+
+
+def _insert_request(
+    *,
+    database_url: str,
+    request_id: str,
+    user_id: str,
+    created_at: int,
+    status: str,
+    source: str,
+    feature_id: str | None,
+) -> None:
+    with psycopg.connect(database_url) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO requests (id, "userId", "createdAt", status, source, "featureId")
+                VALUES (%s, %s, %s, %s, %s, %s)
+                """,
+                (request_id, user_id, created_at, status, source, feature_id),
+            )
+        connection.commit()
+
+
+def _insert_feature(
+    *,
+    database_url: str,
+    feature_id: str,
+    user_id: str,
+    created_at: int,
+    source: str,
+    data: dict[str, object],
+) -> None:
+    with psycopg.connect(database_url) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO features (id, "userId", "createdAt", source, data)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (feature_id, user_id, created_at, source, json.dumps(data)),
+            )
+        connection.commit()

--- a/apps/backend/tests/test_request_fulfillment_service.py
+++ b/apps/backend/tests/test_request_fulfillment_service.py
@@ -271,6 +271,17 @@ def test_request_processing_is_idempotent() -> None:
                 feature_count = cursor.fetchone()[0]
                 cursor.execute(
                     """
+                    SELECT id
+                    FROM features
+                    WHERE "userId" = %s
+                    ORDER BY "createdAt" DESC
+                    LIMIT 1
+                    """,
+                    (user_id,),
+                )
+                feature_row = cursor.fetchone()
+                cursor.execute(
+                    """
                     SELECT status, "featureId"
                     FROM requests
                     WHERE id = %s
@@ -280,9 +291,10 @@ def test_request_processing_is_idempotent() -> None:
                 request_row = cursor.fetchone()
 
         assert feature_count == 1
+        assert feature_row is not None
         assert request_row is not None
         assert request_row[0] == "fulfilled"
-        assert request_row[1] is not None
+        assert request_row[1] == feature_row[0]
 
 
 def test_slow_fetch_completes_without_service_level_timeout_retry() -> None:


### PR DESCRIPTION
## Summary
Implements end-to-end label association for fulfilled feature requests.

## Changes
- Added `labels` table with:
  - `featureId` FK -> `features.id` (`ON DELETE CASCADE`)
  - `requestId` FK -> `requests.id` (`ON DELETE CASCADE`)
  - circumplex `category` check constraint (`energized|calm|stressed|tired`)
- Added `Label` ORM model.
- Added `POST /labels` endpoint.
- Added label request/response schemas.
- Added `LabelRepository` + `LabelService` with:
  - feature ownership verification
  - request resolution via `requests.featureId`
  - persistence + error mapping
- Wired dependencies and router registration.
- Added tests for label creation, ownership rejection, category validation, and cascade behavior.
- Strengthened fulfillment test to explicitly assert `requests.featureId` matches persisted `features.id`.

## Acceptance Criteria Coverage
- Fulfillment sets `requests.featureId`: verified by test assertion.
- User can create label tied to feature: implemented via `POST /labels`.
- Label stores `emotionWord` + `category`: implemented.
- Category restricted to circumplex taxonomy: API + DB constraint.
- Deleting features/requests removes labels: enforced via FK cascade and tested.
- Full request -> feature -> label traceability: implemented via stored `requestId` + `featureId`.
