### PR TITLE
US-041: Add feature snapshot delete confirmation with cascading cleanup messaging

### DIFF
--- a/apps/frontend/src/components/features/DeleteFeatureButton.tsx
+++ b/apps/frontend/src/components/features/DeleteFeatureButton.tsx
@@ -1,0 +1,47 @@
+import { Pressable, StyleSheet, Text } from "react-native";
+
+import { colors, radius, spacing, typography } from "../../theme";
+
+type DeleteFeatureButtonProps = {
+  disabled?: boolean;
+  isLoading?: boolean;
+  onPress: () => void;
+};
+
+export default function DeleteFeatureButton({
+  disabled = false,
+  isLoading = false,
+  onPress
+}: DeleteFeatureButtonProps) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      disabled={disabled || isLoading}
+      onPress={onPress}
+      style={[styles.button, disabled || isLoading ? styles.buttonDisabled : null]}
+      testID="feature-delete-button"
+    >
+      <Text style={styles.buttonText}>{isLoading ? "Deleting..." : "Delete Snapshot"}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    backgroundColor: colors.surface,
+    borderColor: colors.dangerBorder,
+    borderRadius: radius.sm,
+    borderWidth: 1,
+    minHeight: 34,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs
+  },
+  buttonDisabled: {
+    opacity: 0.65
+  },
+  buttonText: {
+    ...typography.helper,
+    color: colors.dangerText,
+    fontWeight: "700"
+  }
+});

--- a/apps/frontend/src/components/features/DeleteFeatureConfirmationModal.tsx
+++ b/apps/frontend/src/components/features/DeleteFeatureConfirmationModal.tsx
@@ -1,0 +1,165 @@
+import { Modal, Pressable, StyleSheet, Text, View } from "react-native";
+
+import type { FeatureRecord } from "../../types/features";
+import { colors, radius, spacing, typography } from "../../theme";
+import {
+  formatFeatureTimestamp,
+  shortenFeatureId
+} from "../../utils/featureHistoryFormatting";
+import AppButton from "../ui/AppButton";
+import AppCard from "../ui/AppCard";
+import InfoText from "../ui/InfoText";
+
+type DeleteFeatureConfirmationModalProps = {
+  errorMessage?: string | null;
+  feature: FeatureRecord | null;
+  isDeleting?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  visible: boolean;
+};
+
+export default function DeleteFeatureConfirmationModal({
+  errorMessage = null,
+  feature,
+  isDeleting = false,
+  onCancel,
+  onConfirm,
+  visible
+}: DeleteFeatureConfirmationModalProps) {
+  if (!visible || !feature) {
+    return null;
+  }
+
+  return (
+    <Modal
+      animationType="fade"
+      onRequestClose={isDeleting ? undefined : onCancel}
+      transparent
+      visible={visible}
+    >
+      <View style={styles.overlay}>
+        <Pressable
+          accessibilityRole="button"
+          disabled={isDeleting}
+          onPress={onCancel}
+          style={StyleSheet.absoluteFill}
+          testID="delete-feature-modal-overlay"
+        />
+        <AppCard style={styles.card} testID="delete-feature-modal">
+          <View style={styles.header}>
+            <Text style={styles.title}>Delete Feature Snapshot?</Text>
+            <InfoText tone="helper">
+              Review what will be removed before confirming this action.
+            </InfoText>
+          </View>
+
+          <View style={styles.contextBlock}>
+            <Text style={styles.contextLabel}>Feature Snapshot</Text>
+            <Text style={styles.contextValue}>{`ID ${shortenFeatureId(feature.id)}`}</Text>
+            <InfoText tone="muted">{formatFeatureTimestamp(feature.createdAt)}</InfoText>
+          </View>
+
+          <View style={styles.body}>
+            <InfoText>This will permanently delete the feature snapshot.</InfoText>
+            <InfoText>Any linked mood labels will also be removed.</InfoText>
+            <InfoText>
+              If a request is linked to this snapshot, it may also be deleted according to the platform&apos;s
+              data cleanup policy.
+            </InfoText>
+            <InfoText tone="danger">This action cannot be undone.</InfoText>
+          </View>
+
+          {errorMessage ? (
+            <View style={styles.errorBlock}>
+              <Text style={styles.errorTitle}>Unable to delete feature snapshot</Text>
+              <InfoText tone="danger">{errorMessage}</InfoText>
+            </View>
+          ) : null}
+
+          <View style={styles.actions}>
+            <AppButton
+              disabled={isDeleting}
+              label="Cancel"
+              onPress={onCancel}
+              style={styles.actionButton}
+              variant="outline"
+            />
+            <AppButton
+              isLoading={isDeleting}
+              label="Delete Snapshot"
+              onPress={onConfirm}
+              style={styles.actionButton}
+              testID="confirm-delete-feature-button"
+              variant="danger"
+            />
+          </View>
+        </AppCard>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  actionButton: {
+    flex: 1
+  },
+  actions: {
+    flexDirection: "row",
+    gap: spacing.sm
+  },
+  body: {
+    gap: spacing.xs
+  },
+  card: {
+    gap: spacing.md,
+    marginHorizontal: spacing.lg,
+    maxWidth: 420,
+    width: "100%"
+  },
+  contextBlock: {
+    backgroundColor: colors.surfaceMuted,
+    borderColor: colors.border,
+    borderRadius: radius.sm,
+    borderWidth: 1,
+    gap: spacing.xxs,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm
+  },
+  contextLabel: {
+    ...typography.helper,
+    color: colors.textMuted,
+    textTransform: "uppercase"
+  },
+  contextValue: {
+    ...typography.bodyStrong,
+    color: colors.textPrimary
+  },
+  errorBlock: {
+    backgroundColor: colors.dangerSurface,
+    borderColor: colors.dangerBorder,
+    borderRadius: radius.sm,
+    borderWidth: 1,
+    gap: spacing.xxs,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm
+  },
+  errorTitle: {
+    ...typography.bodyStrong,
+    color: colors.dangerText
+  },
+  header: {
+    gap: spacing.xxs
+  },
+  overlay: {
+    alignItems: "center",
+    backgroundColor: "rgba(17, 24, 39, 0.36)",
+    flex: 1,
+    justifyContent: "center",
+    padding: spacing.lg
+  },
+  title: {
+    ...typography.sectionTitle,
+    color: colors.textPrimary
+  }
+});

--- a/apps/frontend/src/pages/FeatureDetailPage.test.tsx
+++ b/apps/frontend/src/pages/FeatureDetailPage.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 import { useIsFocused } from "@react-navigation/native";
 
-import { getFeatureById } from "../api/features";
+import { deleteFeature, getFeatureById } from "../api/features";
 import { createApiError } from "../api/errors";
 import type { RootStackParamList } from "../router/AppRouter";
 import type { FeatureRecord } from "../types/features";
@@ -14,6 +14,7 @@ jest.mock("@react-navigation/native", () => ({
 }));
 
 const mockedGetFeatureById = jest.mocked(getFeatureById);
+const mockedDeleteFeature = jest.mocked(deleteFeature);
 const mockedUseIsFocused = jest.mocked(useIsFocused);
 
 function toSeconds(value: string): number {
@@ -64,7 +65,8 @@ const UNLABELED_FEATURE: FeatureRecord = {
 
 function makeProps(id: string) {
   const navigation = {
-    navigate: jest.fn()
+    navigate: jest.fn(),
+    replace: jest.fn()
   } as never;
 
   return {
@@ -177,6 +179,50 @@ describe("FeatureDetailPage", () => {
     await waitFor(() => {
       expect(getByText(/"id": "feature-detail-1"/)).toBeTruthy();
     });
+  });
+
+  it("deletes a feature snapshot from the confirmation modal and returns to history", async () => {
+    mockedGetFeatureById.mockResolvedValue(DETAIL_FEATURE);
+    mockedDeleteFeature.mockResolvedValue({ id: DETAIL_FEATURE.id });
+    const props = makeProps("feature-detail-1");
+    const { getByTestId, getByText } = render(<FeatureDetailPage {...props} />);
+
+    await waitFor(() => {
+      expect(getByTestId("feature-delete-button")).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId("feature-delete-button"));
+
+    expect(getByText("Delete Feature Snapshot?")).toBeTruthy();
+    expect(getByText("Any linked mood labels will also be removed.")).toBeTruthy();
+
+    fireEvent.press(getByTestId("confirm-delete-feature-button"));
+
+    await waitFor(() => {
+      expect(mockedDeleteFeature).toHaveBeenCalledWith("feature-detail-1");
+      expect((props.navigation as never as { replace: jest.Mock }).replace).toHaveBeenCalledWith("Features");
+    });
+  });
+
+  it("shows an error when feature deletion fails", async () => {
+    mockedGetFeatureById.mockResolvedValue(DETAIL_FEATURE);
+    mockedDeleteFeature.mockRejectedValue(new Error("Unable to delete feature snapshot. Please try again."));
+    const props = makeProps("feature-detail-1");
+    const { getByTestId, getByText } = render(<FeatureDetailPage {...props} />);
+
+    await waitFor(() => {
+      expect(getByTestId("feature-delete-button")).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId("feature-delete-button"));
+    fireEvent.press(getByTestId("confirm-delete-feature-button"));
+
+    await waitFor(() => {
+      expect(getByText("Unable to delete feature snapshot")).toBeTruthy();
+      expect(getByText("Unable to delete feature snapshot. Please try again.")).toBeTruthy();
+    });
+
+    expect((props.navigation as never as { replace: jest.Mock }).replace).not.toHaveBeenCalled();
   });
 
   it("renders a not found state when feature id does not resolve", async () => {

--- a/apps/frontend/src/pages/FeatureDetailPage.tsx
+++ b/apps/frontend/src/pages/FeatureDetailPage.tsx
@@ -2,8 +2,10 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { StyleSheet, Text, View } from "react-native";
 
-import { getFeatureById } from "../api/features";
+import { deleteFeature, getFeatureById } from "../api/features";
 import { isApiError } from "../api/errors";
+import DeleteFeatureButton from "../components/features/DeleteFeatureButton";
+import DeleteFeatureConfirmationModal from "../components/features/DeleteFeatureConfirmationModal";
 import FeatureKeyMetricsCard from "../components/features/FeatureKeyMetricsCard";
 import FeatureMetadataCard from "../components/features/FeatureMetadataCard";
 import FeatureSectionCard from "../components/features/FeatureSectionCard";
@@ -38,6 +40,9 @@ function toTabKey(label: string): string {
 
 export default function FeatureDetailPage({ navigation, route }: FeatureDetailPageProps) {
   const { id, refreshAt } = route.params;
+  const [deleteErrorMessage, setDeleteErrorMessage] = useState<string | null>(null);
+  const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const [feature, setFeature] = useState<FeatureRecord | null>(null);
   const [viewState, setViewState] = useState<DetailViewState>("loading");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -107,6 +112,41 @@ export default function FeatureDetailPage({ navigation, route }: FeatureDetailPa
   const handleOpenMoodEditor = useCallback(() => {
     navigation.navigate("FeatureMoodLabel", { id });
   }, [id, navigation]);
+
+  const handleOpenDeleteModal = useCallback(() => {
+    setDeleteErrorMessage(null);
+    setIsDeleteModalVisible(true);
+  }, []);
+
+  const handleCloseDeleteModal = useCallback(() => {
+    if (isDeleting) {
+      return;
+    }
+
+    setDeleteErrorMessage(null);
+    setIsDeleteModalVisible(false);
+  }, [isDeleting]);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!feature) {
+      return;
+    }
+
+    setIsDeleting(true);
+    setDeleteErrorMessage(null);
+
+    try {
+      await deleteFeature(feature.id);
+      setIsDeleteModalVisible(false);
+      setIsDeleting(false);
+      navigation.replace("Features");
+    } catch (error) {
+      setDeleteErrorMessage(
+        error instanceof Error ? error.message : "Unable to delete feature snapshot. Please try again."
+      );
+      setIsDeleting(false);
+    }
+  }, [feature, navigation]);
 
   if (viewState === "loading") {
     return <LoadingState message="Loading feature detail..." />;
@@ -194,6 +234,17 @@ export default function FeatureDetailPage({ navigation, route }: FeatureDetailPa
 
       <FeatureMetadataCard metadata={metadata} />
       <RawJsonToggle payload={feature} />
+      <View style={styles.deleteActionRow}>
+        <DeleteFeatureButton disabled={isDeleting} isLoading={isDeleting} onPress={handleOpenDeleteModal} />
+      </View>
+      <DeleteFeatureConfirmationModal
+        errorMessage={deleteErrorMessage}
+        feature={feature}
+        isDeleting={isDeleting}
+        onCancel={handleCloseDeleteModal}
+        onConfirm={() => void handleConfirmDelete()}
+        visible={isDeleteModalVisible}
+      />
     </View>
   );
 }
@@ -230,6 +281,11 @@ const styles = StyleSheet.create({
   headerMetaValue: {
     ...typography.bodyStrong,
     color: colors.textPrimary
+  },
+  deleteActionRow: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingTop: spacing.xs
   },
   headerTime: {
     ...typography.helper,


### PR DESCRIPTION
## Summary

This PR adds a frontend delete flow for feature snapshots, with a confirmation step that explains the backend's cascading cleanup behavior before the user confirms deletion.

Deleting a snapshot now clearly communicates that:
- the feature snapshot is permanently deleted
- linked mood labels are also removed
- linked request records may also be deleted by the platform's cleanup policy
- the action cannot be undone

## What changed

- Added reusable delete UI primitives for feature snapshots:
  - `DeleteFeatureButton`
  - `DeleteFeatureConfirmationModal`
- Added a destructive `Delete Snapshot` action to the Feature Detail page
- Moved the delete action to the bottom of the detail page and centered it to keep the summary content primary
- Wired the confirmation modal to the existing `DELETE /features/{id}` API call
- Added loading and inline error handling for failed deletes
- On successful delete, the app closes the modal and returns the user to the Features history page
- Added focused test coverage for:
  - opening the confirmation modal
  - successful deletion and navigation
  - failed deletion with error feedback

## UX behavior

- Users delete a feature snapshot from the Feature Detail screen
- Tapping `Delete Snapshot` opens a confirmation modal instead of deleting immediately
- The modal explains the cascading cleanup impact before confirmation
- Confirming deletion disables the destructive action while the request is in flight
- On success, the detail page exits and the deleted snapshot disappears from history
- On failure, the modal stays open and shows a retryable error message

## Testing

- `npm test -- FeatureDetailPage.test.tsx --runInBand`
