### PR TITLE
US-038: Encrypt owner-managed Fitbit secrets at rest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Required for local backend/frontend runtime
 DATABASE_URL=postgresql://mood:mood@localhost:5432/mood
+APP_SECRET_ENCRYPTION_KEY=replace-with-fernet-key
 EXPO_PUBLIC_API_BASE_URL=http://localhost:8000
 
 # Optional for local tooling / verification

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ make db-down
 Fitbit integration now uses database-backed configuration from the Settings screen.
 
 - Save OAuth credentials and webhook secrets through `Settings -> Fitbit Integration`
+- `APP_SECRET_ENCRYPTION_KEY` is required so the backend can encrypt stored client/webhook secrets at rest
 - `FITBIT_WEBHOOK_COALESCE_SECONDS` remains environment-driven
 - legacy Fitbit env vars in `.env.example` are optional and not required for normal runtime operation
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -137,14 +137,23 @@ Fitbit integration settings endpoints:
   - creates or updates the singleton `integration_settings` row
   - validates `clientId`, `clientSecret`, and `redirectUri`
   - preserves the existing client secret when the update omits it
+  - encrypts secret values before writing them to the database
 
 Configuration loading flow:
 
 1. The owner saves Fitbit OAuth credentials in the frontend Settings screen.
-2. The backend stores them in the `integration_settings` table.
-3. FastAPI Fitbit dependencies merge that row into runtime Fitbit settings.
-4. OAuth start/callback, token refresh, webhook verification, and worker Fitbit pulls all read the same stored configuration.
-5. If no saved configuration exists, Fitbit OAuth/webhook flows return `Fitbit integration not configured.`
+2. The backend encrypts `clientSecret` and `webhookSecret` with `APP_SECRET_ENCRYPTION_KEY`.
+3. Ciphertext is stored in the `integration_settings` table; plaintext is discarded.
+4. FastAPI Fitbit dependencies decrypt those values only when building runtime Fitbit settings.
+5. OAuth start/callback, token refresh, webhook verification, and worker Fitbit pulls all read the same stored configuration.
+6. If no saved configuration exists, Fitbit OAuth/webhook flows return `Fitbit integration not configured.`
+
+Required secret-management environment variable:
+
+- `APP_SECRET_ENCRYPTION_KEY`
+  - must be a valid Fernet key
+  - used to encrypt/decrypt stored Fitbit secrets
+  - must not be stored in the database
 
 Webhook verification endpoint:
 
@@ -166,9 +175,10 @@ Webhook ingestion endpoint:
 Local webhook ingestion test:
 
 1. Set env vars:
-   - `FITBIT_WEBHOOK_SECRET`
+   - `APP_SECRET_ENCRYPTION_KEY`
    - `FITBIT_WEBHOOK_COALESCE_SECONDS` (optional; default `10`)
-2. Generate test payload + signature (Python one-liner):
+2. Save a webhook secret through `PUT /settings/fitbit` or the frontend Settings screen.
+3. Generate test payload + signature (Python one-liner):
    ```bash
    python - <<'PY'
    import hashlib, hmac
@@ -176,7 +186,7 @@ Local webhook ingestion test:
    print(hmac.new(b"replace-with-fitbit-webhook-secret", body, hashlib.sha256).hexdigest())
    PY
    ```
-3. Send request:
+4. Send request:
    ```bash
    curl -i -X POST http://localhost:8000/fitbit/webhook \
      -H "Content-Type: application/json" \
@@ -195,6 +205,7 @@ Managed in the database through `PUT /settings/fitbit`:
 
 Still environment-driven:
 
+- `APP_SECRET_ENCRYPTION_KEY`
 - `FITBIT_AUTH_BASE_URL` (default: `https://www.fitbit.com/oauth2/authorize`)
 - `FITBIT_TOKEN_URL` (default: `https://api.fitbit.com/oauth2/token`)
 - `FITBIT_WEBHOOK_COALESCE_SECONDS`

--- a/apps/backend/alembic/versions/20260309_000018_encrypt_integration_settings_secrets.py
+++ b/apps/backend/alembic/versions/20260309_000018_encrypt_integration_settings_secrets.py
@@ -1,0 +1,173 @@
+"""encrypt integration settings secrets at rest
+
+Revision ID: 20260309_000018
+Revises: 20260309_000017
+Create Date: 2026-03-09 00:00:18.000000
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from cryptography.fernet import Fernet
+
+revision: str = "20260309_000018"
+down_revision: str | None = "20260309_000017"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _normalize_secret(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+
+    normalized_value = value.strip()
+    if not normalized_value:
+        return None
+
+    return normalized_value
+
+
+def _get_fernet(*, required: bool) -> Fernet | None:
+    encryption_key = os.getenv("APP_SECRET_ENCRYPTION_KEY", "").strip()
+    if not encryption_key:
+        if required:
+            raise RuntimeError(
+                "APP_SECRET_ENCRYPTION_KEY is required to migrate encrypted integration secrets."
+            )
+        return None
+
+    try:
+        return Fernet(encryption_key.encode("utf-8"))
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("APP_SECRET_ENCRYPTION_KEY must be a valid Fernet key.") from exc
+
+
+def _encrypt_if_present(*, fernet: Fernet | None, value: object) -> str | None:
+    normalized_value = _normalize_secret(value)
+    if normalized_value is None:
+        return None
+
+    if fernet is None:
+        raise RuntimeError(
+            "APP_SECRET_ENCRYPTION_KEY is required to migrate encrypted integration secrets."
+        )
+
+    return fernet.encrypt(normalized_value.encode("utf-8")).decode("utf-8")
+
+
+def upgrade() -> None:
+    op.add_column(
+        "integration_settings",
+        sa.Column("fitbit_client_secret_encrypted", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "integration_settings",
+        sa.Column("fitbit_webhook_secret_encrypted", sa.Text(), nullable=True),
+    )
+
+    bind = op.get_bind()
+    integration_settings = sa.table(
+        "integration_settings",
+        sa.column("id", sa.Integer()),
+        sa.column("fitbit_client_secret", sa.Text()),
+        sa.column("fitbit_webhook_secret", sa.Text()),
+        sa.column("fitbit_client_secret_encrypted", sa.Text()),
+        sa.column("fitbit_webhook_secret_encrypted", sa.Text()),
+    )
+    existing_rows = bind.execute(
+        sa.select(
+            integration_settings.c.id,
+            integration_settings.c.fitbit_client_secret,
+            integration_settings.c.fitbit_webhook_secret,
+        )
+    ).mappings()
+
+    rows_to_encrypt = list(existing_rows)
+    requires_key = any(
+        _normalize_secret(row["fitbit_client_secret"])
+        or _normalize_secret(row["fitbit_webhook_secret"])
+        for row in rows_to_encrypt
+    )
+    fernet = _get_fernet(required=requires_key)
+
+    for row in rows_to_encrypt:
+        bind.execute(
+            sa.update(integration_settings)
+            .where(integration_settings.c.id == row["id"])
+            .values(
+                fitbit_client_secret_encrypted=_encrypt_if_present(
+                    fernet=fernet,
+                    value=row["fitbit_client_secret"],
+                ),
+                fitbit_webhook_secret_encrypted=_encrypt_if_present(
+                    fernet=fernet,
+                    value=row["fitbit_webhook_secret"],
+                ),
+            )
+        )
+
+    op.drop_column("integration_settings", "fitbit_client_secret")
+    op.drop_column("integration_settings", "fitbit_webhook_secret")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "integration_settings",
+        sa.Column("fitbit_webhook_secret", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "integration_settings",
+        sa.Column("fitbit_client_secret", sa.Text(), nullable=True),
+    )
+
+    bind = op.get_bind()
+    integration_settings = sa.table(
+        "integration_settings",
+        sa.column("id", sa.Integer()),
+        sa.column("fitbit_client_secret", sa.Text()),
+        sa.column("fitbit_webhook_secret", sa.Text()),
+        sa.column("fitbit_client_secret_encrypted", sa.Text()),
+        sa.column("fitbit_webhook_secret_encrypted", sa.Text()),
+    )
+    existing_rows = bind.execute(
+        sa.select(
+            integration_settings.c.id,
+            integration_settings.c.fitbit_client_secret_encrypted,
+            integration_settings.c.fitbit_webhook_secret_encrypted,
+        )
+    ).mappings()
+
+    rows_to_decrypt = list(existing_rows)
+    requires_key = any(
+        _normalize_secret(row["fitbit_client_secret_encrypted"])
+        or _normalize_secret(row["fitbit_webhook_secret_encrypted"])
+        for row in rows_to_decrypt
+    )
+    fernet = _get_fernet(required=requires_key)
+
+    for row in rows_to_decrypt:
+        client_secret = _normalize_secret(row["fitbit_client_secret_encrypted"])
+        webhook_secret = _normalize_secret(row["fitbit_webhook_secret_encrypted"])
+        bind.execute(
+            sa.update(integration_settings)
+            .where(integration_settings.c.id == row["id"])
+            .values(
+                fitbit_client_secret=(
+                    fernet.decrypt(client_secret.encode("utf-8")).decode("utf-8")
+                    if client_secret and fernet is not None
+                    else None
+                ),
+                fitbit_webhook_secret=(
+                    fernet.decrypt(webhook_secret.encode("utf-8")).decode("utf-8")
+                    if webhook_secret and fernet is not None
+                    else None
+                ),
+            )
+        )
+
+    op.drop_column("integration_settings", "fitbit_client_secret_encrypted")
+    op.drop_column("integration_settings", "fitbit_webhook_secret_encrypted")

--- a/apps/backend/app/db/models.py
+++ b/apps/backend/app/db/models.py
@@ -212,11 +212,11 @@ class IntegrationSettings(Base):
 
     id: Mapped[int] = mapped_column(sa.Integer, primary_key=True, server_default=sa.text("1"))
     fitbit_client_id: Mapped[str | None] = mapped_column(sa.Text)
-    fitbit_client_secret: Mapped[str | None] = mapped_column(sa.Text)
+    fitbit_client_secret_encrypted: Mapped[str | None] = mapped_column(sa.Text)
     fitbit_redirect_uri: Mapped[str | None] = mapped_column(sa.Text)
     fitbit_oauth_scope: Mapped[str | None] = mapped_column(sa.Text)
     fitbit_subscriber_id: Mapped[str | None] = mapped_column(sa.Text)
-    fitbit_webhook_secret: Mapped[str | None] = mapped_column(sa.Text)
+    fitbit_webhook_secret_encrypted: Mapped[str | None] = mapped_column(sa.Text)
     created_at: Mapped[datetime] = mapped_column(
         sa.DateTime(timezone=True),
         nullable=False,

--- a/apps/backend/app/dependencies.py
+++ b/apps/backend/app/dependencies.py
@@ -113,7 +113,10 @@ def get_fitbit_integration_settings_service(
         IntegrationSettingsRepository, Depends(get_integration_settings_repository)
     ],
 ) -> FitbitIntegrationSettingsService:
-    return FitbitIntegrationSettingsService(repository=integration_settings_repository)
+    return FitbitIntegrationSettingsService(
+        repository=integration_settings_repository,
+        encryption_key=get_settings().APP_SECRET_ENCRYPTION_KEY,
+    )
 
 
 def get_fitbit_runtime_settings(

--- a/apps/backend/app/repositories/integration_settings_repository.py
+++ b/apps/backend/app/repositories/integration_settings_repository.py
@@ -34,11 +34,11 @@ class IntegrationSettingsRepository:
         self,
         *,
         client_id: str,
-        client_secret: str,
+        client_secret_encrypted: str,
         redirect_uri: str,
         scope: str | None,
         subscriber_id: str | None,
-        webhook_secret: str | None,
+        webhook_secret_encrypted: str | None,
     ) -> IntegrationSettings:
         try:
             self._session.execute(
@@ -46,21 +46,21 @@ class IntegrationSettingsRepository:
                 .values(
                     id=SINGLETON_SETTINGS_ID,
                     fitbit_client_id=client_id,
-                    fitbit_client_secret=client_secret,
+                    fitbit_client_secret_encrypted=client_secret_encrypted,
                     fitbit_redirect_uri=redirect_uri,
                     fitbit_oauth_scope=scope,
                     fitbit_subscriber_id=subscriber_id,
-                    fitbit_webhook_secret=webhook_secret,
+                    fitbit_webhook_secret_encrypted=webhook_secret_encrypted,
                 )
                 .on_conflict_do_update(
                     index_elements=[IntegrationSettings.id],
                     set_={
                         "fitbit_client_id": client_id,
-                        "fitbit_client_secret": client_secret,
+                        "fitbit_client_secret_encrypted": client_secret_encrypted,
                         "fitbit_redirect_uri": redirect_uri,
                         "fitbit_oauth_scope": scope,
                         "fitbit_subscriber_id": subscriber_id,
-                        "fitbit_webhook_secret": webhook_secret,
+                        "fitbit_webhook_secret_encrypted": webhook_secret_encrypted,
                         "updated_at": sa.func.now(),
                     },
                 )

--- a/apps/backend/app/services/encryption_service.py
+++ b/apps/backend/app/services/encryption_service.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from cryptography.fernet import Fernet, InvalidToken
+
+
+class EncryptionServiceConfigurationError(Exception):
+    pass
+
+
+class EncryptionServiceDecryptError(Exception):
+    pass
+
+
+class EncryptionService:
+    def __init__(self, *, encryption_key: str) -> None:
+        normalized_key = encryption_key.strip()
+        if not normalized_key:
+            raise EncryptionServiceConfigurationError(
+                "APP_SECRET_ENCRYPTION_KEY is required for encrypted integration settings."
+            )
+
+        try:
+            self._fernet = Fernet(normalized_key.encode("utf-8"))
+        except (TypeError, ValueError) as exc:
+            raise EncryptionServiceConfigurationError(
+                "APP_SECRET_ENCRYPTION_KEY must be a valid Fernet key."
+            ) from exc
+
+    def encrypt_value(self, plaintext: str) -> str:
+        return self._fernet.encrypt(plaintext.encode("utf-8")).decode("utf-8")
+
+    def decrypt_value(self, ciphertext: str) -> str:
+        try:
+            return self._fernet.decrypt(ciphertext.encode("utf-8")).decode("utf-8")
+        except (InvalidToken, ValueError, TypeError) as exc:
+            raise EncryptionServiceDecryptError(
+                "Failed to decrypt encrypted integration secret."
+            ) from exc
+
+
+@lru_cache
+def build_encryption_service(encryption_key: str) -> EncryptionService:
+    return EncryptionService(encryption_key=encryption_key)
+
+
+def mask_secret(secret: str | None) -> str | None:
+    if not isinstance(secret, str):
+        return None
+
+    normalized_secret = secret.strip()
+    if not normalized_secret:
+        return None
+
+    if len(normalized_secret) <= 4:
+        return "*" * len(normalized_secret)
+
+    return f"********{normalized_secret[-4:]}"

--- a/apps/backend/app/services/fitbit_data_client.py
+++ b/apps/backend/app/services/fitbit_data_client.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from app.repositories.fitbit_token_repository import FitbitTokenRepository
 from app.repositories.integration_settings_repository import IntegrationSettingsRepository
 from app.services.fitbit_api_client import FitbitApiClient
-from app.services.fitbit_integration_settings_service import build_fitbit_runtime_settings
+from app.services.fitbit_integration_settings_service import FitbitIntegrationSettingsService
 from app.services.fitbit_token_service import FitbitTokenService
 from app.settings import Settings, get_settings
 
@@ -103,12 +103,11 @@ class FitbitSignalPullClient:
         self._timezone_cache_ttl_seconds = max(60, self._settings.FITBIT_TIMEZONE_CACHE_TTL_SECONDS)
 
     def _load_runtime_settings(self, *, session: Session) -> Settings:
-        repository = IntegrationSettingsRepository(session=session)
-        stored_settings = repository.get_settings()
-        return build_fitbit_runtime_settings(
-            base_settings=self._settings,
-            integration_settings=stored_settings,
+        service = FitbitIntegrationSettingsService(
+            repository=IntegrationSettingsRepository(session=session),
+            encryption_key=self._settings.APP_SECRET_ENCRYPTION_KEY,
         )
+        return service.get_runtime_settings(base_settings=self._settings)
 
     def fetch_user_data(self, *, user_id: str) -> dict[str, Any]:
         date_iso = datetime.now(tz=UTC).date().isoformat()

--- a/apps/backend/app/services/fitbit_integration_settings_service.py
+++ b/apps/backend/app/services/fitbit_integration_settings_service.py
@@ -7,6 +7,12 @@ from app.repositories.integration_settings_repository import (
     IntegrationSettingsRepository,
     IntegrationSettingsRepositoryError,
 )
+from app.services.encryption_service import (
+    EncryptionServiceConfigurationError,
+    EncryptionServiceDecryptError,
+    build_encryption_service,
+    mask_secret,
+)
 from app.settings import DEFAULT_FITBIT_OAUTH_SCOPE, Settings
 
 
@@ -38,46 +44,33 @@ def _normalize_text(value: str | None) -> str:
     return value.strip()
 
 
-def mask_secret(value: str | None) -> str | None:
-    normalized = _normalize_text(value)
-    if not normalized:
-        return None
-    if len(normalized) <= 4:
-        return "*" * len(normalized)
-    return f"********{normalized[-4:]}"
-
-
-def build_fitbit_runtime_settings(
-    *,
-    base_settings: Settings,
-    integration_settings: IntegrationSettings | None,
-) -> Settings:
-    if integration_settings is None:
-        return replace(
-            base_settings,
-            FITBIT_CLIENT_ID="",
-            FITBIT_CLIENT_SECRET="",
-            FITBIT_REDIRECT_URI="",
-            FITBIT_OAUTH_SCOPE=DEFAULT_FITBIT_OAUTH_SCOPE,
-            FITBIT_SUBSCRIBER_ID="",
-            FITBIT_WEBHOOK_SECRET="",
-        )
-
-    normalized_scope = _normalize_text(integration_settings.fitbit_oauth_scope)
-    return replace(
-        base_settings,
-        FITBIT_CLIENT_ID=_normalize_text(integration_settings.fitbit_client_id),
-        FITBIT_CLIENT_SECRET=_normalize_text(integration_settings.fitbit_client_secret),
-        FITBIT_REDIRECT_URI=_normalize_text(integration_settings.fitbit_redirect_uri),
-        FITBIT_OAUTH_SCOPE=normalized_scope or DEFAULT_FITBIT_OAUTH_SCOPE,
-        FITBIT_SUBSCRIBER_ID=_normalize_text(integration_settings.fitbit_subscriber_id),
-        FITBIT_WEBHOOK_SECRET=_normalize_text(integration_settings.fitbit_webhook_secret),
-    )
-
-
 class FitbitIntegrationSettingsService:
-    def __init__(self, repository: IntegrationSettingsRepository) -> None:
+    def __init__(
+        self,
+        repository: IntegrationSettingsRepository,
+        *,
+        encryption_key: str,
+    ) -> None:
         self._repository = repository
+        self._encryption_key = encryption_key
+
+    def _get_encryption_service(self):
+        try:
+            return build_encryption_service(self._encryption_key)
+        except EncryptionServiceConfigurationError as exc:
+            raise FitbitIntegrationSettingsServiceError(str(exc)) from exc
+
+    def _decrypt_secret(self, encrypted_value: str | None) -> str:
+        normalized_value = _normalize_text(encrypted_value)
+        if not normalized_value:
+            return ""
+
+        try:
+            return self._get_encryption_service().decrypt_value(normalized_value)
+        except EncryptionServiceDecryptError as exc:
+            raise FitbitIntegrationSettingsServiceError(
+                "Failed to decrypt Fitbit integration settings."
+            ) from exc
 
     def get_settings_view(self) -> FitbitIntegrationSettingsView:
         try:
@@ -95,9 +88,30 @@ class FitbitIntegrationSettingsService:
             raise FitbitIntegrationSettingsServiceError(
                 "Failed to load Fitbit integration settings."
             ) from exc
-        return build_fitbit_runtime_settings(
-            base_settings=base_settings,
-            integration_settings=stored_settings,
+        if stored_settings is None:
+            return replace(
+                base_settings,
+                FITBIT_CLIENT_ID="",
+                FITBIT_CLIENT_SECRET="",
+                FITBIT_REDIRECT_URI="",
+                FITBIT_OAUTH_SCOPE=DEFAULT_FITBIT_OAUTH_SCOPE,
+                FITBIT_SUBSCRIBER_ID="",
+                FITBIT_WEBHOOK_SECRET="",
+            )
+
+        normalized_scope = _normalize_text(stored_settings.fitbit_oauth_scope)
+        return replace(
+            base_settings,
+            FITBIT_CLIENT_ID=_normalize_text(stored_settings.fitbit_client_id),
+            FITBIT_CLIENT_SECRET=self._decrypt_secret(
+                stored_settings.fitbit_client_secret_encrypted
+            ),
+            FITBIT_REDIRECT_URI=_normalize_text(stored_settings.fitbit_redirect_uri),
+            FITBIT_OAUTH_SCOPE=normalized_scope or DEFAULT_FITBIT_OAUTH_SCOPE,
+            FITBIT_SUBSCRIBER_ID=_normalize_text(stored_settings.fitbit_subscriber_id),
+            FITBIT_WEBHOOK_SECRET=self._decrypt_secret(
+                stored_settings.fitbit_webhook_secret_encrypted
+            ),
         )
 
     def upsert_settings(
@@ -125,9 +139,15 @@ class FitbitIntegrationSettingsService:
         normalized_webhook_secret = (
             None if webhook_secret is None else _normalize_text(webhook_secret)
         )
-
-        current_client_secret = _normalize_text(
-            stored_settings.fitbit_client_secret if stored_settings is not None else None
+        current_client_secret_encrypted = (
+            _normalize_text(stored_settings.fitbit_client_secret_encrypted)
+            if stored_settings is not None
+            else ""
+        )
+        current_webhook_secret_encrypted = (
+            _normalize_text(stored_settings.fitbit_webhook_secret_encrypted)
+            if stored_settings is not None
+            else ""
         )
 
         errors: dict[str, str] = {}
@@ -136,32 +156,34 @@ class FitbitIntegrationSettingsService:
         if not normalized_redirect_uri:
             errors["redirectUri"] = "Redirect URI is required."
 
-        if normalized_client_secret is None:
-            secret_to_store = current_client_secret
+        if normalized_client_secret:
+            client_secret_encrypted = self._get_encryption_service().encrypt_value(
+                normalized_client_secret
+            )
         else:
-            secret_to_store = normalized_client_secret
+            client_secret_encrypted = current_client_secret_encrypted
 
-        if not secret_to_store:
+        if not client_secret_encrypted:
             errors["clientSecret"] = "Client Secret is required."
 
         if errors:
             raise FitbitIntegrationSettingsValidationError(errors)
 
-        if normalized_webhook_secret is None:
-            webhook_secret_to_store = _normalize_text(
-                stored_settings.fitbit_webhook_secret if stored_settings is not None else None
+        if normalized_webhook_secret:
+            webhook_secret_encrypted = self._get_encryption_service().encrypt_value(
+                normalized_webhook_secret
             )
         else:
-            webhook_secret_to_store = normalized_webhook_secret
+            webhook_secret_encrypted = current_webhook_secret_encrypted or None
 
         try:
             updated_settings = self._repository.upsert_fitbit_settings(
                 client_id=normalized_client_id,
-                client_secret=secret_to_store,
+                client_secret_encrypted=client_secret_encrypted,
                 redirect_uri=normalized_redirect_uri,
                 scope=normalized_scope or None,
                 subscriber_id=normalized_subscriber_id or None,
-                webhook_secret=webhook_secret_to_store or None,
+                webhook_secret_encrypted=webhook_secret_encrypted,
             )
         except IntegrationSettingsRepositoryError as exc:
             raise FitbitIntegrationSettingsServiceError(
@@ -185,8 +207,12 @@ class FitbitIntegrationSettingsService:
                 has_webhook_secret=False,
             )
 
-        normalized_client_secret = _normalize_text(stored_settings.fitbit_client_secret)
-        normalized_webhook_secret = _normalize_text(stored_settings.fitbit_webhook_secret)
+        normalized_client_secret = self._decrypt_secret(
+            stored_settings.fitbit_client_secret_encrypted
+        )
+        normalized_webhook_secret = self._decrypt_secret(
+            stored_settings.fitbit_webhook_secret_encrypted
+        )
         normalized_scope = _normalize_text(stored_settings.fitbit_oauth_scope)
 
         return FitbitIntegrationSettingsView(

--- a/apps/backend/app/settings.py
+++ b/apps/backend/app/settings.py
@@ -24,6 +24,7 @@ DEFAULT_FITBIT_TIMEZONE_CACHE_TTL_SECONDS = 7 * 24 * 60 * 60
 @dataclass(frozen=True)
 class Settings:
     FEATURE_EXTRACTOR_VERSION: str = DEFAULT_FEATURE_EXTRACTOR_VERSION
+    APP_SECRET_ENCRYPTION_KEY: str = ""
     FITBIT_CLIENT_ID: str = ""
     FITBIT_CLIENT_SECRET: str = ""
     FITBIT_REDIRECT_URI: str = ""
@@ -159,6 +160,7 @@ def get_settings() -> Settings:
 
     return Settings(
         FEATURE_EXTRACTOR_VERSION=configured_version,
+        APP_SECRET_ENCRYPTION_KEY=os.getenv("APP_SECRET_ENCRYPTION_KEY", "").strip(),
         FITBIT_CLIENT_ID=os.getenv("FITBIT_CLIENT_ID", "").strip(),
         FITBIT_CLIENT_SECRET=os.getenv("FITBIT_CLIENT_SECRET", "").strip(),
         FITBIT_REDIRECT_URI=os.getenv("FITBIT_REDIRECT_URI", "").strip(),

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -5,3 +5,4 @@ sqlalchemy
 uvicorn[standard]
 psycopg[binary]
 redis
+cryptography

--- a/apps/backend/tests/test_encryption_service.py
+++ b/apps/backend/tests/test_encryption_service.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+from app.services.encryption_service import (
+    EncryptionServiceConfigurationError,
+    EncryptionServiceDecryptError,
+    build_encryption_service,
+    mask_secret,
+)
+
+TEST_ENCRYPTION_KEY = "Qv2K-KSS7eDYAf9H2JWzImrxNr7AWyP3w7k3TKTKuig="
+
+
+def test_encryption_service_round_trips_plaintext() -> None:
+    service = build_encryption_service(TEST_ENCRYPTION_KEY)
+
+    ciphertext = service.encrypt_value("fitbit-secret-1234")
+
+    assert ciphertext != "fitbit-secret-1234"
+    assert service.decrypt_value(ciphertext) == "fitbit-secret-1234"
+
+
+def test_encryption_service_rejects_missing_key() -> None:
+    with pytest.raises(EncryptionServiceConfigurationError):
+        build_encryption_service("")
+
+
+def test_encryption_service_rejects_invalid_ciphertext() -> None:
+    service = build_encryption_service(TEST_ENCRYPTION_KEY)
+
+    with pytest.raises(EncryptionServiceDecryptError):
+        service.decrypt_value("not-a-valid-fernet-token")
+
+
+def test_mask_secret_only_exposes_last_four_chars() -> None:
+    assert mask_secret("fitbit-secret-1234") == "********1234"
+    assert mask_secret("1234") == "****"
+    assert mask_secret("") is None

--- a/apps/backend/tests/test_fitbit_oauth_endpoints.py
+++ b/apps/backend/tests/test_fitbit_oauth_endpoints.py
@@ -10,6 +10,7 @@ from urllib.parse import parse_qs, urlparse
 import psycopg
 from app.db import session as db_session
 from app.main import app
+from app.services.encryption_service import build_encryption_service
 from app.services.fitbit_oauth_service import FitbitOAuthService
 from fastapi.testclient import TestClient
 from psycopg import sql
@@ -18,6 +19,7 @@ from sqlalchemy.engine import make_url
 ROOT_DIR = Path(__file__).resolve().parents[3]
 ALEMBIC_CONFIG = ROOT_DIR / "apps" / "backend" / "alembic.ini"
 OWNER_USER_ID = "00000000-0000-0000-0000-00000000fa01"
+TEST_ENCRYPTION_KEY = "Qv2K-KSS7eDYAf9H2JWzImrxNr7AWyP3w7k3TKTKuig="
 
 
 def test_fitbit_oauth_start_redirects_to_fitbit(monkeypatch) -> None:
@@ -275,6 +277,7 @@ class _temporary_database:
 def _run_alembic_upgrade(*, database_url: str) -> None:
     env = os.environ.copy()
     env["DATABASE_URL"] = database_url
+    env["APP_SECRET_ENCRYPTION_KEY"] = TEST_ENCRYPTION_KEY
     subprocess.run(
         [
             sys.executable,
@@ -293,11 +296,13 @@ def _run_alembic_upgrade(*, database_url: str) -> None:
 
 def _configure_runtime_env(*, monkeypatch, database_url: str) -> None:
     monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("APP_SECRET_ENCRYPTION_KEY", TEST_ENCRYPTION_KEY)
     monkeypatch.setenv("OWNER_USER_ID", OWNER_USER_ID)
     db_session._session_factory.cache_clear()
 
 
 def _seed_fitbit_integration_settings(*, database_url: str) -> None:
+    encryption_service = build_encryption_service(TEST_ENCRYPTION_KEY)
     with psycopg.connect(database_url) as connection:
         with connection.cursor() as cursor:
             cursor.execute(
@@ -305,21 +310,21 @@ def _seed_fitbit_integration_settings(*, database_url: str) -> None:
                 INSERT INTO integration_settings (
                     id,
                     fitbit_client_id,
-                    fitbit_client_secret,
+                    fitbit_client_secret_encrypted,
                     fitbit_redirect_uri,
                     fitbit_oauth_scope
                 )
                 VALUES (1, %s, %s, %s, %s)
                 ON CONFLICT (id) DO UPDATE
                 SET fitbit_client_id = EXCLUDED.fitbit_client_id,
-                    fitbit_client_secret = EXCLUDED.fitbit_client_secret,
+                    fitbit_client_secret_encrypted = EXCLUDED.fitbit_client_secret_encrypted,
                     fitbit_redirect_uri = EXCLUDED.fitbit_redirect_uri,
                     fitbit_oauth_scope = EXCLUDED.fitbit_oauth_scope,
                     updated_at = now()
                 """,
                 (
                     "test-fitbit-client-id",
-                    "test-fitbit-client-secret",
+                    encryption_service.encrypt_value("test-fitbit-client-secret"),
                     "http://localhost:8000/fitbit/oauth/callback",
                     "sleep heartrate activity profile",
                 ),

--- a/apps/backend/tests/test_fitbit_settings_endpoints.py
+++ b/apps/backend/tests/test_fitbit_settings_endpoints.py
@@ -9,12 +9,14 @@ from pathlib import Path
 import psycopg
 from app.db import session as db_session
 from app.main import app
+from app.services.encryption_service import build_encryption_service
 from fastapi.testclient import TestClient
 from psycopg import sql
 from sqlalchemy.engine import make_url
 
 ROOT_DIR = Path(__file__).resolve().parents[3]
 ALEMBIC_CONFIG = ROOT_DIR / "apps" / "backend" / "alembic.ini"
+TEST_ENCRYPTION_KEY = "Qv2K-KSS7eDYAf9H2JWzImrxNr7AWyP3w7k3TKTKuig="
 
 
 def test_get_fitbit_settings_returns_masked_values(monkeypatch) -> None:
@@ -84,25 +86,27 @@ def test_put_fitbit_settings_stores_and_masks_values(monkeypatch) -> None:
                     """
                     SELECT
                         fitbit_client_id,
-                        fitbit_client_secret,
+                        fitbit_client_secret_encrypted,
                         fitbit_redirect_uri,
                         fitbit_oauth_scope,
                         fitbit_subscriber_id,
-                        fitbit_webhook_secret
+                        fitbit_webhook_secret_encrypted
                     FROM integration_settings
                     WHERE id = 1
                     """
                 )
                 row = cursor.fetchone()
 
-        assert row == (
-            "new-fitbit-client",
-            "new-fitbit-secret-2222",
-            "http://localhost:8000/fitbit/oauth/callback",
-            "activity heartrate sleep",
-            "subscriber-2",
-            "new-webhook-secret-3333",
-        )
+        assert row is not None
+        assert row[0] == "new-fitbit-client"
+        assert row[1] != "new-fitbit-secret-2222"
+        assert row[2] == "http://localhost:8000/fitbit/oauth/callback"
+        assert row[3] == "activity heartrate sleep"
+        assert row[4] == "subscriber-2"
+        assert row[5] != "new-webhook-secret-3333"
+        encryption_service = build_encryption_service(TEST_ENCRYPTION_KEY)
+        assert encryption_service.decrypt_value(row[1]) == "new-fitbit-secret-2222"
+        assert encryption_service.decrypt_value(row[5]) == "new-webhook-secret-3333"
         db_session._session_factory.cache_clear()
 
 
@@ -138,14 +142,17 @@ def test_put_fitbit_settings_preserves_existing_client_secret_when_omitted(monke
             with connection.cursor() as cursor:
                 cursor.execute(
                     """
-                    SELECT fitbit_client_secret, fitbit_subscriber_id
+                    SELECT fitbit_client_secret_encrypted, fitbit_subscriber_id
                     FROM integration_settings
                     WHERE id = 1
                     """
                 )
                 row = cursor.fetchone()
 
-        assert row == ("fitbit-secret-1234", "subscriber-9")
+        assert row is not None
+        encryption_service = build_encryption_service(TEST_ENCRYPTION_KEY)
+        assert encryption_service.decrypt_value(row[0]) == "fitbit-secret-1234"
+        assert row[1] == "subscriber-9"
         db_session._session_factory.cache_clear()
 
 
@@ -218,6 +225,7 @@ class _temporary_database:
 def _run_alembic_upgrade(*, database_url: str) -> None:
     env = os.environ.copy()
     env["DATABASE_URL"] = database_url
+    env["APP_SECRET_ENCRYPTION_KEY"] = TEST_ENCRYPTION_KEY
     subprocess.run(
         [
             sys.executable,
@@ -236,6 +244,7 @@ def _run_alembic_upgrade(*, database_url: str) -> None:
 
 def _configure_runtime_env(*, monkeypatch, database_url: str) -> None:
     monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("APP_SECRET_ENCRYPTION_KEY", TEST_ENCRYPTION_KEY)
     db_session._session_factory.cache_clear()
 
 
@@ -249,6 +258,7 @@ def _seed_fitbit_integration_settings(
     subscriber_id: str,
     webhook_secret: str,
 ) -> None:
+    encryption_service = build_encryption_service(TEST_ENCRYPTION_KEY)
     with psycopg.connect(database_url) as connection:
         with connection.cursor() as cursor:
             cursor.execute(
@@ -256,29 +266,29 @@ def _seed_fitbit_integration_settings(
                 INSERT INTO integration_settings (
                     id,
                     fitbit_client_id,
-                    fitbit_client_secret,
+                    fitbit_client_secret_encrypted,
                     fitbit_redirect_uri,
                     fitbit_oauth_scope,
                     fitbit_subscriber_id,
-                    fitbit_webhook_secret
+                    fitbit_webhook_secret_encrypted
                 )
                 VALUES (1, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (id) DO UPDATE
                 SET fitbit_client_id = EXCLUDED.fitbit_client_id,
-                    fitbit_client_secret = EXCLUDED.fitbit_client_secret,
+                    fitbit_client_secret_encrypted = EXCLUDED.fitbit_client_secret_encrypted,
                     fitbit_redirect_uri = EXCLUDED.fitbit_redirect_uri,
                     fitbit_oauth_scope = EXCLUDED.fitbit_oauth_scope,
                     fitbit_subscriber_id = EXCLUDED.fitbit_subscriber_id,
-                    fitbit_webhook_secret = EXCLUDED.fitbit_webhook_secret,
+                    fitbit_webhook_secret_encrypted = EXCLUDED.fitbit_webhook_secret_encrypted,
                     updated_at = now()
                 """,
                 (
                     client_id,
-                    client_secret,
+                    encryption_service.encrypt_value(client_secret),
                     redirect_uri,
                     scope,
                     subscriber_id,
-                    webhook_secret,
+                    encryption_service.encrypt_value(webhook_secret),
                 ),
             )
         connection.commit()

--- a/apps/backend/tests/test_fitbit_webhook_ingestion.py
+++ b/apps/backend/tests/test_fitbit_webhook_ingestion.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import psycopg
 from app.db import session as db_session
 from app.main import app
+from app.services.encryption_service import build_encryption_service
 from fastapi.testclient import TestClient
 from psycopg import sql
 from sqlalchemy.engine import make_url
@@ -22,6 +23,7 @@ OWNER_USER_ID = "00000000-0000-0000-0000-00000000bb01"
 FITBIT_USER_ID = "fitbit-user-1"
 WEBHOOK_SECRET = "test-fitbit-webhook-secret"
 WEBHOOK_URL = "/fitbit/webhook"
+TEST_ENCRYPTION_KEY = "Qv2K-KSS7eDYAf9H2JWzImrxNr7AWyP3w7k3TKTKuig="
 
 
 def test_webhook_valid_signature_returns_204(monkeypatch) -> None:
@@ -243,6 +245,7 @@ class _temporary_database:
 def _run_alembic_upgrade(*, database_url: str) -> None:
     env = os.environ.copy()
     env["DATABASE_URL"] = database_url
+    env["APP_SECRET_ENCRYPTION_KEY"] = TEST_ENCRYPTION_KEY
     subprocess.run(
         [
             sys.executable,
@@ -261,6 +264,7 @@ def _run_alembic_upgrade(*, database_url: str) -> None:
 
 def _configure_runtime_env(*, monkeypatch, database_url: str) -> None:
     monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("APP_SECRET_ENCRYPTION_KEY", TEST_ENCRYPTION_KEY)
     monkeypatch.setenv("FITBIT_WEBHOOK_COALESCE_SECONDS", "10")
     db_session._session_factory.cache_clear()
 
@@ -292,16 +296,17 @@ def _build_signature(*, secret: str, raw_body: bytes) -> str:
 
 
 def _seed_fitbit_integration_settings(*, database_url: str, webhook_secret: str) -> None:
+    encryption_service = build_encryption_service(TEST_ENCRYPTION_KEY)
     with psycopg.connect(database_url) as connection:
         with connection.cursor() as cursor:
             cursor.execute(
                 """
-                INSERT INTO integration_settings (id, fitbit_webhook_secret)
+                INSERT INTO integration_settings (id, fitbit_webhook_secret_encrypted)
                 VALUES (1, %s)
                 ON CONFLICT (id) DO UPDATE
-                SET fitbit_webhook_secret = EXCLUDED.fitbit_webhook_secret,
+                SET fitbit_webhook_secret_encrypted = EXCLUDED.fitbit_webhook_secret_encrypted,
                     updated_at = now()
                 """,
-                (webhook_secret,),
+                (encryption_service.encrypt_value(webhook_secret),),
             )
         connection.commit()


### PR DESCRIPTION
## Summary

This PR secures owner-managed Fitbit integration secrets in the backend.

Fitbit client secrets and webhook secrets are now encrypted at rest in PostgreSQL, decrypted only for internal runtime use, and never returned in plaintext through the settings API. This builds on the database-backed Settings flow from US-037.

## What changed

- Added a reusable Fernet-based encryption service for backend secrets
- Added `APP_SECRET_ENCRYPTION_KEY` as the server-side encryption key source
- Migrated `integration_settings` secret storage from plaintext columns to encrypted ciphertext columns:
  - `fitbit_client_secret_encrypted`
  - `fitbit_webhook_secret_encrypted`
- Updated Fitbit integration settings read/write behavior so:
  - incoming secrets are encrypted before persistence
  - existing encrypted secrets are preserved when secret fields are omitted
  - secrets are only decrypted for internal runtime configuration
- Kept API responses masked using `clientSecretMasked` and `webhookSecretMasked`
- Updated Fitbit runtime loading so OAuth, token refresh, webhook verification, and data pulls use decrypted values internally
- Added focused backend coverage for encryption behavior, masked responses, encrypted persistence, and runtime integration
- Updated docs and `.env.example` to document `APP_SECRET_ENCRYPTION_KEY` and the encrypted storage flow

## Security behavior

- Secrets are encrypted before writing to the database
- Plaintext secrets are not returned by the API
- Plaintext secrets are not stored in `integration_settings`
- Existing secrets do not need to be re-entered on every update
- `APP_SECRET_ENCRYPTION_KEY` remains server-side only and is not stored in the database

## Testing

- `apps/backend/tests/test_encryption_service.py`
- `apps/backend/tests/test_fitbit_settings_endpoints.py`
- `apps/backend/tests/test_fitbit_oauth_endpoints.py`
- `apps/backend/tests/test_fitbit_webhook_ingestion.py`
- `apps/backend/tests/test_fitbit_oauth_service.py`
- `apps/backend/tests/test_fitbit_token_service.py`

Focused result: `25 passed`
